### PR TITLE
Add supply chain inventory agent network

### DIFF
--- a/coded_tools/supply_chain_inventory.py
+++ b/coded_tools/supply_chain_inventory.py
@@ -1,0 +1,64 @@
+from typing import Any, Dict
+
+from neuro_san.interfaces.coded_tool import CodedTool
+
+
+class ForecastDemand(CodedTool):
+    """Return a dummy demand forecast for a product."""
+
+    def invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> Dict[str, Any]:
+        product = args.get("product", "item")
+        # Dummy forecast value
+        return {"product": product, "forecast": 100}
+
+    async def async_invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> Dict[str, Any]:
+        return self.invoke(args, sly_data)
+
+
+class OptimizeInventory(CodedTool):
+    """Provide a simple reorder recommendation."""
+
+    def invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> Dict[str, Any]:
+        forecast = float(args.get("forecast", 0))
+        current_stock = float(args.get("current_stock", 0))
+        lead_time = float(args.get("lead_time", 0))
+        reorder = max(forecast - current_stock + lead_time, 0)
+        return {"reorder_quantity": reorder}
+
+    async def async_invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> Dict[str, Any]:
+        return self.invoke(args, sly_data)
+
+
+class CreatePurchaseOrder(CodedTool):
+    """Create a placeholder purchase order."""
+
+    def invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> str:
+        product = args.get("product", "item")
+        quantity = args.get("quantity", 0)
+        return f"Purchase order created for {quantity} units of {product}"
+
+    async def async_invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> str:
+        return self.invoke(args, sly_data)
+
+
+class CheckStock(CodedTool):
+    """Report on-hand stock levels."""
+
+    def invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> Dict[str, Any]:
+        product = args.get("product", "item")
+        on_hand = sly_data.get("inventory", {}).get(product, 0)
+        return {"product": product, "on_hand": on_hand}
+
+    async def async_invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> Dict[str, Any]:
+        return self.invoke(args, sly_data)
+
+
+class GenerateReport(CodedTool):
+    """Generate a simple text report."""
+
+    def invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> str:
+        report_type = args.get("report_type", "summary")
+        return f"Generated {report_type} report"
+
+    async def async_invoke(self, args: Dict[str, Any], sly_data: Dict[str, Any]) -> str:
+        return self.invoke(args, sly_data)

--- a/registries/manifest.hocon
+++ b/registries/manifest.hocon
@@ -114,6 +114,7 @@
     "intranet_agents_with_tools.hocon": true,
     "real_estate.hocon": false,
     "retail_ops_and_customer_service.hocon": true,
+    "supply_chain_inventory.hocon": true,
     "telco_network_support.hocon": true,
     "therapy_vignette_supervisors.hocon": true,
     "consumer_decision_assistant.hocon": true,

--- a/registries/supply_chain_inventory.hocon
+++ b/registries/supply_chain_inventory.hocon
@@ -1,0 +1,83 @@
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+{
+    "llm_config": {
+        "model_name": "gpt-4o",
+    },
+    "max_iterations": 4000,
+    "max_execution_seconds": 600,
+    "commondefs": {},
+    "tools": [
+        {
+            "name": "inventory_planner",
+            "function": {
+                "description": "Top-level coordinator for supply chain inventory planning queries.",
+            },
+            "instructions": """You coordinate forecasting, optimization, procurement, warehouse tracking, and reporting to answer user questions about inventory. Gather required details, delegate to specialists, and combine their results into a clear response.""",
+            "tools": ["demand_forecaster", "inventory_optimizer", "procurement_agent", "warehouse_manager", "reporting_agent"]
+        },
+        {
+            "name": "demand_forecaster",
+            "function": {
+                "description": "Predicts product demand from sales history.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "product": {
+                            "type": "string",
+                            "description": "Product to forecast demand for."
+                        }
+                    },
+                    "required": ["product"]
+                }
+            },
+            "instructions": """Estimate upcoming demand for the specified product based on historical data and trends.""",
+            "tools": ["forecast_demand"]
+        },
+        {
+            "name": "inventory_optimizer",
+            "function": {
+                "description": "Balances stock levels, lead times, and carrying costs.",
+            },
+            "instructions": """Recommend reorder quantities and safety stock using demand forecasts and current inventory data.""",
+            "tools": ["optimize_inventory"]
+        },
+        {
+            "name": "procurement_agent",
+            "function": {
+                "description": "Orders from suppliers.",
+            },
+            "instructions": """Create purchase orders to replenish inventory when required.""",
+            "tools": ["create_purchase_order"]
+        },
+        {
+            "name": "warehouse_manager",
+            "function": {
+                "description": "Tracks on-hand quantities.",
+            },
+            "instructions": """Monitor warehouse stock levels and provide availability details.""",
+            "tools": ["check_stock"]
+        },
+        {
+            "name": "reporting_agent",
+            "function": {
+                "description": "Summaries and dashboards for stakeholders.",
+            },
+            "instructions": """Compile inputs from other agents into concise status reports.""",
+            "tools": ["generate_report"]
+        },
+        {"name": "forecast_demand", "toolbox": "forecast_demand"},
+        {"name": "optimize_inventory", "toolbox": "optimize_inventory"},
+        {"name": "create_purchase_order", "toolbox": "create_purchase_order"},
+        {"name": "check_stock", "toolbox": "check_stock"},
+        {"name": "generate_report", "toolbox": "generate_report"}
+    ]
+}

--- a/toolbox/toolbox_info.hocon
+++ b/toolbox/toolbox_info.hocon
@@ -284,4 +284,65 @@
         }
     }
 
+    "forecast_demand": {
+        "class": "supply_chain_inventory.ForecastDemand",
+        "description": "Forecast product demand from sales history.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "product": {
+                    "type": "string",
+                    "description": "Product identifier."
+                }
+            },
+            "required": ["product"]
+        }
+    },
+    "optimize_inventory": {
+        "class": "supply_chain_inventory.OptimizeInventory",
+        "description": "Recommend reorder quantities based on demand and current stock.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "forecast": {"type": "number", "description": "Forecasted demand"},
+                "current_stock": {"type": "number", "description": "Current inventory"},
+                "lead_time": {"type": "number", "description": "Lead time"}
+            },
+            "required": ["forecast", "current_stock", "lead_time"]
+        }
+    },
+    "create_purchase_order": {
+        "class": "supply_chain_inventory.CreatePurchaseOrder",
+        "description": "Create a purchase order for a product.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "product": {"type": "string", "description": "Product to order"},
+                "quantity": {"type": "number", "description": "Quantity to order"}
+            },
+            "required": ["product", "quantity"]
+        }
+    },
+    "check_stock": {
+        "class": "supply_chain_inventory.CheckStock",
+        "description": "Check on-hand inventory levels for a product.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "product": {"type": "string", "description": "Product to check"}
+            },
+            "required": ["product"]
+        }
+    },
+    "generate_report": {
+        "class": "supply_chain_inventory.GenerateReport",
+        "description": "Generate simple supply chain reports.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "report_type": {"type": "string", "description": "Type of report"}
+            },
+            "required": ["report_type"]
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add `supply_chain_inventory.hocon` with inventory planning agents and tool wiring
- implement coded tools for forecasting, optimization, purchasing, stock checks, and reporting
- expose new tools in toolbox and enable network in manifest

## Testing
- `pytest -q --override-ini="addopts="` *(fails: ProxyError: HTTPSConnectionPool(host='api.salesforce.com', port=443): Max retries exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_6896fc8a71c883238d37d6e6f1ddb8a5